### PR TITLE
Add function returning array of stp

### DIFF
--- a/examples/dedx_get_stp_table.c
+++ b/examples/dedx_get_stp_table.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <dedx.h>
+
+int main()
+{
+    int err = 0;
+    float energies[100];
+    float results[100];
+    int program = DEDX_BETHE_EXT00;
+    int ion = DEDX_HYDROGEN;
+    int target = DEDX_WATER_LIQUID;
+    int no_of_points = 100;
+    for(int i = 1; i < no_of_points + 1; i++){
+        energies[i - 1] = i * 1.1;
+    }
+
+    err = dedx_get_stp_table(program, ion, target, no_of_points, energies, results);
+    if (err != 0) printf("Encountered error no. %d", err);
+    else
+        for(int i = 0; i < no_of_points; i++)
+            printf("%f \n", results[i]);
+
+    return 0;
+}

--- a/libdedx/dedx.c
+++ b/libdedx/dedx.c
@@ -663,6 +663,27 @@ int _dedx_load_atima(stopping_data * data, dedx_config * config, float * energy,
 	return 0;
 }
 
+//energy - in MeV/nucleon, unless  program is ESTAR, then MeV
+//stp - in MeVcm2/g
+int dedx_get_stp_table(const int program, const int ion, const int target, const int no_of_points, const float *energies, float *stps) {
+    int err = 0;
+    dedx_config *config = (dedx_config *)calloc(1,sizeof(dedx_config));
+    config->target = target;
+    config->ion = ion;
+    config->program = program;
+    dedx_workspace *ws = dedx_allocate_workspace(1, &err);
+
+    if (err != 0) return err;
+    dedx_load_config(ws,config, &err);
+
+    for(int i = 0 ; i < no_of_points; i++){
+        stps[i] =  dedx_get_stp(ws, config, energies[i], &err);
+    }
+    dedx_free_config(config, &err);
+    dedx_free_workspace(ws, &err);
+
+    return err;
+}
 
 
 float dedx_get_stp(dedx_workspace * ws, dedx_config * config, float energy, int * err)

--- a/libdedx/dedx.h
+++ b/libdedx/dedx.h
@@ -212,6 +212,7 @@ float dedx_get_stp(dedx_workspace * ws,
 		dedx_config * config, float energy, int * err);
 float dedx_get_simple_stp(int ion, int target, float energy, int *err);
 void dedx_free_config(dedx_config * config, int *err);
+int dedx_get_stp_table(int program, int ion, int target, int no_of_points, const float *energies, float *stps);
 /*
    dedx_config must be specified BEFORE calling dedx_load_config()
 


### PR DESCRIPTION
Added function enabling returning an array of calculations 
Arguments as following:
`const int program, const int ion, const int target - these are required by the function calculating single stp value. There is also energy required (described below)
`const int no_of_points` - number of points that we want to get values of
`const float *energies` - array of energies to calculate stopping power 
`float *stps` - pointer where to return values (so its webassembly compatible)