### PR TITLE
Delete .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,0 @@
-tasks:
-  - init: |
-      pip install sphinx
-      pip install -r docs/source/requirements.txt


### PR DESCRIPTION
This pull request makes a minor update by removing the documentation-related setup commands from the `.gitpod.yml` file. These commands previously installed Sphinx and other documentation requirements during the Gitpod workspace initialization.

Gitpod is paid now