### PR TITLE
feat: expose nucleon number, atom mass, density and is-gas accessors (#119)

### DIFF
--- a/examples/dedx_list.c
+++ b/examples/dedx_list.c
@@ -25,15 +25,20 @@ int main(int argc, char *argv[]) {
     for (i = 0; i < 300; ++i)
         printf(" %3i %s\n", i, dedx_get_material_name(i));
 
-    /* Material / ion property accessors */
+    /* Material / ion property accessors. Each accessor writes to *err, so the
+     * values are read into temporaries first — passing one &err to several
+     * calls inside a single printf would leave the writes unsequenced. */
     {
         int err = 0;
-        printf("\nCarbon ion: A=%d, atomic mass=%.4f u\n",
-               dedx_get_nucleon_number(DEDX_CARBON, &err),
-               dedx_get_atom_mass(DEDX_CARBON, &err));
-        printf(
-            "Water: density=%.4f g/cm^3, gas=%d\n", dedx_get_density(DEDX_WATER, &err), dedx_is_gas(DEDX_WATER, &err));
-        printf("Air:   density=%.4g g/cm^3, gas=%d\n", dedx_get_density(DEDX_AIR, &err), dedx_is_gas(DEDX_AIR, &err));
+        int carbon_a = dedx_get_nucleon_number(DEDX_CARBON, &err);
+        float carbon_mass = dedx_get_atom_mass(DEDX_CARBON, &err);
+        float water_rho = dedx_get_density(DEDX_WATER, &err);
+        int water_gas = dedx_is_gas(DEDX_WATER, &err);
+        float air_rho = dedx_get_density(DEDX_AIR, &err);
+        int air_gas = dedx_is_gas(DEDX_AIR, &err);
+        printf("\nCarbon ion: A=%d, atomic mass=%.4f u\n", carbon_a, carbon_mass);
+        printf("Water: density=%.4f g/cm^3, gas=%d\n", water_rho, water_gas);
+        printf("Air:   density=%.4g g/cm^3, gas=%d\n", air_rho, air_gas);
     }
 
     // printf("NB: %i\n", DEDX_WATER);

--- a/examples/dedx_list.c
+++ b/examples/dedx_list.c
@@ -25,6 +25,17 @@ int main(int argc, char *argv[]) {
     for (i = 0; i < 300; ++i)
         printf(" %3i %s\n", i, dedx_get_material_name(i));
 
+    /* Material / ion property accessors */
+    {
+        int err = 0;
+        printf("\nCarbon ion: A=%d, atomic mass=%.4f u\n",
+               dedx_get_nucleon_number(DEDX_CARBON, &err),
+               dedx_get_atom_mass(DEDX_CARBON, &err));
+        printf(
+            "Water: density=%.4f g/cm^3, gas=%d\n", dedx_get_density(DEDX_WATER, &err), dedx_is_gas(DEDX_WATER, &err));
+        printf("Air:   density=%.4g g/cm^3, gas=%d\n", dedx_get_density(DEDX_AIR, &err), dedx_is_gas(DEDX_AIR, &err));
+    }
+
     // printf("NB: %i\n", DEDX_WATER);
     return 0;
 }

--- a/include/dedx.h
+++ b/include/dedx.h
@@ -173,7 +173,8 @@ float dedx_get_density(int material, int *err);
 
 /** @brief Report whether a target material is gaseous.
  *  @param[in]  target  Material identifier.
- *  @param[out] err     Error code; DEDX_OK on success.
+ *  @param[out] err     Error code; always set to DEDX_OK — an unknown target is
+ *                      reported as non-gas rather than as an error.
  *  @return 1 if the target is flagged gaseous, 0 otherwise (including unknown targets).
  */
 int dedx_is_gas(int target, int *err);

--- a/include/dedx.h
+++ b/include/dedx.h
@@ -147,6 +147,37 @@ void dedx_get_composition(int target, float composition[][2], unsigned int *comp
  */
 float dedx_get_i_value(int target, int *err);
 
+/** @brief Return the nucleon number (mass number A) of an elemental ion.
+ *  @param[in]  ion  Elemental ion identifier (atomic number Z, 1–112).
+ *  @param[out] err  Error code; DEDX_OK on success, DEDX_ERR_NOT_AN_ELEMENT
+ *                   if @p ion is outside the tabulated element range.
+ *  @return Nucleon number, or -1 on error.
+ */
+int dedx_get_nucleon_number(int ion, int *err);
+
+/** @brief Return the standard atomic mass of an elemental ion.
+ *  @param[in]  ion  Elemental ion identifier (atomic number Z, 1–112).
+ *  @param[out] err  Error code; DEDX_OK on success, DEDX_ERR_NOT_AN_ELEMENT
+ *                   if @p ion is outside the tabulated element range.
+ *  @return Atomic mass in u (unified atomic mass units), or -1 on error.
+ */
+float dedx_get_atom_mass(int ion, int *err);
+
+/** @brief Return the default density of a target material.
+ *  @param[in]  material  Material identifier.
+ *  @param[out] err       Error code; DEDX_OK on success, DEDX_ERR_TARGET_NOT_FOUND
+ *                        if @p material has no embedded density metadata.
+ *  @return Density in g/cm³, or 0 on error.
+ */
+float dedx_get_density(int material, int *err);
+
+/** @brief Report whether a target material is gaseous.
+ *  @param[in]  target  Material identifier.
+ *  @param[out] err     Error code; DEDX_OK on success.
+ *  @return 1 if the target is flagged gaseous, 0 otherwise (including unknown targets).
+ */
+int dedx_is_gas(int target, int *err);
+
 /** @brief Return a null-terminated list of supported program identifiers.
  *  @return Pointer to a static array terminated by 0; do not free.
  */

--- a/src/dedx.c
+++ b/src/dedx.c
@@ -221,6 +221,35 @@ float dedx_get_i_value(int target, int *err) {
     return dedx_internal_get_i_value(target, DEDX_GAS, err);
 }
 
+/* Highest atomic number with tabulated mass/nucleon data (see dedx_amu / dedx_nucl). */
+#define DEDX_MAX_ELEMENT_Z 112
+
+int dedx_get_nucleon_number(int ion, int *err) {
+    /* The internal lookup only guards the upper bound; reject ion <= 0 here
+     * so we never index the table with a negative offset. */
+    if (ion < 1 || ion > DEDX_MAX_ELEMENT_Z) {
+        *err = DEDX_ERR_NOT_AN_ELEMENT;
+        return -1;
+    }
+    return dedx_internal_get_nucleon(ion, err);
+}
+
+float dedx_get_atom_mass(int ion, int *err) {
+    if (ion < 1 || ion > DEDX_MAX_ELEMENT_Z) {
+        *err = DEDX_ERR_NOT_AN_ELEMENT;
+        return -1.0f;
+    }
+    return dedx_internal_get_atom_mass(ion, err);
+}
+
+float dedx_get_density(int material, int *err) {
+    return dedx_internal_read_density(material, err);
+}
+
+int dedx_is_gas(int target, int *err) {
+    return dedx_internal_target_is_gas(target, err) != 0 ? 1 : 0;
+}
+
 const int *dedx_get_program_list(void) {
     /* returns a list of available programs, terminated with -1 */
     return dedx_available_programs;

--- a/tests/test_accessors.c
+++ b/tests/test_accessors.c
@@ -1,0 +1,135 @@
+#include <dedx.h>
+#include <dedx_error.h>
+#include <math.h>
+#include <stdio.h>
+
+/* Tests for the public material/ion property accessors:
+ *   dedx_get_nucleon_number, dedx_get_atom_mass, dedx_get_density, dedx_is_gas.
+ * These promote previously-internal helpers to the public API (issue #119).
+ */
+
+static int faili(const char *label, int got, int expected) {
+    if (got == expected)
+        return 0;
+    fprintf(stderr, "FAIL %s: got %d expected %d\n", label, got, expected);
+    return 1;
+}
+
+static int failmsg(const char *label, const char *message) {
+    fprintf(stderr, "FAIL %s: %s\n", label, message);
+    return 1;
+}
+
+static int check_close(const char *label, double got, double expected, double rel) {
+    double scale = fabs(expected) > 1e-12 ? fabs(expected) : 1.0;
+
+    if (fabs(got - expected) > rel * scale) {
+        fprintf(stderr, "FAIL %s: got %.8g expected %.8g\n", label, got, expected);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+    int err;
+    int nucleons;
+    float mass;
+    float density;
+    int gas;
+
+    /* --- nucleon number: valid elements --- */
+    err = -1;
+    nucleons = dedx_get_nucleon_number(DEDX_HYDROGEN, &err);
+    failures += faili("nucleon H err", err, DEDX_OK);
+    failures += faili("nucleon H value", nucleons, 1);
+
+    err = -1;
+    nucleons = dedx_get_nucleon_number(DEDX_HELIUM, &err);
+    failures += faili("nucleon He err", err, DEDX_OK);
+    failures += faili("nucleon He value", nucleons, 4);
+
+    err = -1;
+    nucleons = dedx_get_nucleon_number(DEDX_CARBON, &err);
+    failures += faili("nucleon C err", err, DEDX_OK);
+    failures += faili("nucleon C value", nucleons, 12);
+
+    /* --- nucleon number: out-of-range guards (lower bound the internal lacks) --- */
+    err = DEDX_OK;
+    nucleons = dedx_get_nucleon_number(0, &err);
+    failures += faili("nucleon 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
+    failures += faili("nucleon 0 sentinel", nucleons, -1);
+
+    err = DEDX_OK;
+    nucleons = dedx_get_nucleon_number(-5, &err);
+    failures += faili("nucleon negative err", err, DEDX_ERR_NOT_AN_ELEMENT);
+    failures += faili("nucleon negative sentinel", nucleons, -1);
+
+    err = DEDX_OK;
+    nucleons = dedx_get_nucleon_number(113, &err);
+    failures += faili("nucleon 113 err", err, DEDX_ERR_NOT_AN_ELEMENT);
+    failures += faili("nucleon 113 sentinel", nucleons, -1);
+
+    /* --- atom mass: valid elements --- */
+    err = -1;
+    mass = dedx_get_atom_mass(DEDX_HYDROGEN, &err);
+    failures += faili("mass H err", err, DEDX_OK);
+    failures += check_close("mass H value", mass, 1.00794, 1e-4);
+
+    err = -1;
+    mass = dedx_get_atom_mass(DEDX_CARBON, &err);
+    failures += faili("mass C err", err, DEDX_OK);
+    failures += check_close("mass C value", mass, 12.0107, 1e-4);
+
+    /* --- atom mass: out-of-range guards --- */
+    err = DEDX_OK;
+    mass = dedx_get_atom_mass(0, &err);
+    failures += faili("mass 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
+    if (mass != -1.0f)
+        failures += failmsg("mass 0 sentinel", "expected -1 on out-of-range element");
+
+    err = DEDX_OK;
+    mass = dedx_get_atom_mass(200, &err);
+    failures += faili("mass 200 err", err, DEDX_ERR_NOT_AN_ELEMENT);
+    if (mass != -1.0f)
+        failures += failmsg("mass 200 sentinel", "expected -1 on out-of-range element");
+
+    /* --- density: known liquid and gaseous materials --- */
+    err = -1;
+    density = dedx_get_density(DEDX_WATER, &err);
+    failures += faili("density water err", err, DEDX_OK);
+    failures += check_close("density water value", density, 1.0, 0.02);
+
+    err = -1;
+    density = dedx_get_density(DEDX_AIR, &err);
+    failures += faili("density air err", err, DEDX_OK);
+    if (density <= 0.0f || density > 0.01f)
+        failures += failmsg("density air value", "air density outside plausible gas range");
+
+    /* --- density: unknown material returns a safe sentinel + error --- */
+    err = DEDX_OK;
+    density = dedx_get_density(9999, &err);
+    failures += faili("density unknown err", err, DEDX_ERR_TARGET_NOT_FOUND);
+    if (density != 0.0f)
+        failures += failmsg("density unknown sentinel", "expected 0 density on unknown material");
+
+    /* --- is_gas: liquid vs gas --- */
+    err = -1;
+    gas = dedx_is_gas(DEDX_WATER, &err);
+    failures += faili("is_gas water err", err, DEDX_OK);
+    failures += faili("is_gas water value", gas, 0);
+
+    err = -1;
+    gas = dedx_is_gas(DEDX_AIR, &err);
+    failures += faili("is_gas air err", err, DEDX_OK);
+    failures += faili("is_gas air value", gas, 1);
+
+    /* Unknown target is reported as non-gas (documented behaviour). */
+    err = -1;
+    gas = dedx_is_gas(9999, &err);
+    failures += faili("is_gas unknown value", gas, 0);
+
+    if (failures == 0)
+        printf("test_accessors: all checks passed\n");
+    return failures;
+}

--- a/tests/test_accessors.c
+++ b/tests/test_accessors.c
@@ -127,6 +127,7 @@ int main(void) {
     /* Unknown target is reported as non-gas (documented behaviour). */
     err = -1;
     gas = dedx_is_gas(9999, &err);
+    failures += faili("is_gas unknown err", err, DEDX_OK);
     failures += faili("is_gas unknown value", gas, 0);
 
     if (failures == 0)

--- a/tests/test_accessors.c
+++ b/tests/test_accessors.c
@@ -6,129 +6,120 @@
 /* Tests for the public material/ion property accessors:
  *   dedx_get_nucleon_number, dedx_get_atom_mass, dedx_get_density, dedx_is_gas.
  * These promote previously-internal helpers to the public API (issue #119).
+ *
+ * All assertions funnel through the three expect_* helpers below so the only
+ * lines that stay uncovered on a passing run are their (shared) failure paths.
  */
 
-static int faili(const char *label, int got, int expected) {
-    if (got == expected)
-        return 0;
-    fprintf(stderr, "FAIL %s: got %d expected %d\n", label, got, expected);
-    return 1;
+static int failures = 0;
+
+static void expect_int(const char *label, long got, long expected) {
+    if (got != expected) {
+        fprintf(stderr, "FAIL %s: got %ld expected %ld\n", label, got, expected);
+        failures++;
+    }
 }
 
-static int failmsg(const char *label, const char *message) {
-    fprintf(stderr, "FAIL %s: %s\n", label, message);
-    return 1;
-}
-
-static int check_close(const char *label, double got, double expected, double rel) {
+static void expect_near(const char *label, double got, double expected, double rel) {
     double scale = fabs(expected) > 1e-12 ? fabs(expected) : 1.0;
-
     if (fabs(got - expected) > rel * scale) {
         fprintf(stderr, "FAIL %s: got %.8g expected %.8g\n", label, got, expected);
-        return 1;
+        failures++;
     }
-    return 0;
+}
+
+static void expect_true(const char *label, int condition) {
+    if (!condition) {
+        fprintf(stderr, "FAIL %s\n", label);
+        failures++;
+    }
 }
 
 int main(void) {
-    int failures = 0;
     int err;
-    int nucleons;
-    float mass;
-    float density;
-    int gas;
+    float air;
 
     /* --- nucleon number: valid elements --- */
     err = -1;
-    nucleons = dedx_get_nucleon_number(DEDX_HYDROGEN, &err);
-    failures += faili("nucleon H err", err, DEDX_OK);
-    failures += faili("nucleon H value", nucleons, 1);
+    expect_int("nucleon H value", dedx_get_nucleon_number(DEDX_HYDROGEN, &err), 1);
+    expect_int("nucleon H err", err, DEDX_OK);
 
     err = -1;
-    nucleons = dedx_get_nucleon_number(DEDX_HELIUM, &err);
-    failures += faili("nucleon He err", err, DEDX_OK);
-    failures += faili("nucleon He value", nucleons, 4);
+    expect_int("nucleon He value", dedx_get_nucleon_number(DEDX_HELIUM, &err), 4);
+    expect_int("nucleon He err", err, DEDX_OK);
 
     err = -1;
-    nucleons = dedx_get_nucleon_number(DEDX_CARBON, &err);
-    failures += faili("nucleon C err", err, DEDX_OK);
-    failures += faili("nucleon C value", nucleons, 12);
+    expect_int("nucleon C value", dedx_get_nucleon_number(DEDX_CARBON, &err), 12);
+    expect_int("nucleon C err", err, DEDX_OK);
+
+    /* Highest tabulated element (Z=112) must be accepted (upper boundary). */
+    err = -1;
+    expect_true("nucleon Z=112 value", dedx_get_nucleon_number(112, &err) > 0);
+    expect_int("nucleon Z=112 err", err, DEDX_OK);
 
     /* --- nucleon number: out-of-range guards (lower bound the internal lacks) --- */
     err = DEDX_OK;
-    nucleons = dedx_get_nucleon_number(0, &err);
-    failures += faili("nucleon 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
-    failures += faili("nucleon 0 sentinel", nucleons, -1);
+    expect_int("nucleon 0 value", dedx_get_nucleon_number(0, &err), -1);
+    expect_int("nucleon 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
 
     err = DEDX_OK;
-    nucleons = dedx_get_nucleon_number(-5, &err);
-    failures += faili("nucleon negative err", err, DEDX_ERR_NOT_AN_ELEMENT);
-    failures += faili("nucleon negative sentinel", nucleons, -1);
+    expect_int("nucleon negative value", dedx_get_nucleon_number(-5, &err), -1);
+    expect_int("nucleon negative err", err, DEDX_ERR_NOT_AN_ELEMENT);
 
     err = DEDX_OK;
-    nucleons = dedx_get_nucleon_number(113, &err);
-    failures += faili("nucleon 113 err", err, DEDX_ERR_NOT_AN_ELEMENT);
-    failures += faili("nucleon 113 sentinel", nucleons, -1);
+    expect_int("nucleon 113 value", dedx_get_nucleon_number(113, &err), -1);
+    expect_int("nucleon 113 err", err, DEDX_ERR_NOT_AN_ELEMENT);
 
     /* --- atom mass: valid elements --- */
     err = -1;
-    mass = dedx_get_atom_mass(DEDX_HYDROGEN, &err);
-    failures += faili("mass H err", err, DEDX_OK);
-    failures += check_close("mass H value", mass, 1.00794, 1e-4);
+    expect_near("mass H value", dedx_get_atom_mass(DEDX_HYDROGEN, &err), 1.00794, 1e-4);
+    expect_int("mass H err", err, DEDX_OK);
 
     err = -1;
-    mass = dedx_get_atom_mass(DEDX_CARBON, &err);
-    failures += faili("mass C err", err, DEDX_OK);
-    failures += check_close("mass C value", mass, 12.0107, 1e-4);
+    expect_near("mass C value", dedx_get_atom_mass(DEDX_CARBON, &err), 12.0107, 1e-4);
+    expect_int("mass C err", err, DEDX_OK);
+
+    err = -1;
+    expect_near("mass O value", dedx_get_atom_mass(DEDX_OXYGEN, &err), 15.9994, 1e-4);
+    expect_int("mass O err", err, DEDX_OK);
 
     /* --- atom mass: out-of-range guards --- */
     err = DEDX_OK;
-    mass = dedx_get_atom_mass(0, &err);
-    failures += faili("mass 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
-    if (mass != -1.0f)
-        failures += failmsg("mass 0 sentinel", "expected -1 on out-of-range element");
+    expect_true("mass 0 sentinel", dedx_get_atom_mass(0, &err) == -1.0f);
+    expect_int("mass 0 err", err, DEDX_ERR_NOT_AN_ELEMENT);
 
     err = DEDX_OK;
-    mass = dedx_get_atom_mass(200, &err);
-    failures += faili("mass 200 err", err, DEDX_ERR_NOT_AN_ELEMENT);
-    if (mass != -1.0f)
-        failures += failmsg("mass 200 sentinel", "expected -1 on out-of-range element");
+    expect_true("mass 200 sentinel", dedx_get_atom_mass(200, &err) == -1.0f);
+    expect_int("mass 200 err", err, DEDX_ERR_NOT_AN_ELEMENT);
 
     /* --- density: known liquid and gaseous materials --- */
     err = -1;
-    density = dedx_get_density(DEDX_WATER, &err);
-    failures += faili("density water err", err, DEDX_OK);
-    failures += check_close("density water value", density, 1.0, 0.02);
+    expect_near("density water value", dedx_get_density(DEDX_WATER, &err), 1.0, 0.02);
+    expect_int("density water err", err, DEDX_OK);
 
     err = -1;
-    density = dedx_get_density(DEDX_AIR, &err);
-    failures += faili("density air err", err, DEDX_OK);
-    if (density <= 0.0f || density > 0.01f)
-        failures += failmsg("density air value", "air density outside plausible gas range");
+    air = dedx_get_density(DEDX_AIR, &err);
+    expect_true("density air range", air > 0.0f && air < 0.01f);
+    expect_int("density air err", err, DEDX_OK);
 
     /* --- density: unknown material returns a safe sentinel + error --- */
     err = DEDX_OK;
-    density = dedx_get_density(9999, &err);
-    failures += faili("density unknown err", err, DEDX_ERR_TARGET_NOT_FOUND);
-    if (density != 0.0f)
-        failures += failmsg("density unknown sentinel", "expected 0 density on unknown material");
+    expect_true("density unknown sentinel", dedx_get_density(9999, &err) == 0.0f);
+    expect_int("density unknown err", err, DEDX_ERR_TARGET_NOT_FOUND);
 
     /* --- is_gas: liquid vs gas --- */
     err = -1;
-    gas = dedx_is_gas(DEDX_WATER, &err);
-    failures += faili("is_gas water err", err, DEDX_OK);
-    failures += faili("is_gas water value", gas, 0);
+    expect_int("is_gas water value", dedx_is_gas(DEDX_WATER, &err), 0);
+    expect_int("is_gas water err", err, DEDX_OK);
 
     err = -1;
-    gas = dedx_is_gas(DEDX_AIR, &err);
-    failures += faili("is_gas air err", err, DEDX_OK);
-    failures += faili("is_gas air value", gas, 1);
+    expect_int("is_gas air value", dedx_is_gas(DEDX_AIR, &err), 1);
+    expect_int("is_gas air err", err, DEDX_OK);
 
-    /* Unknown target is reported as non-gas (documented behaviour). */
+    /* Unknown target is reported as non-gas, never an error (documented). */
     err = -1;
-    gas = dedx_is_gas(9999, &err);
-    failures += faili("is_gas unknown err", err, DEDX_OK);
-    failures += faili("is_gas unknown value", gas, 0);
+    expect_int("is_gas unknown value", dedx_is_gas(9999, &err), 0);
+    expect_int("is_gas unknown err", err, DEDX_OK);
 
     if (failures == 0)
         printf("test_accessors: all checks passed\n");


### PR DESCRIPTION
Closes #119 · Phase A of the `dedx_extra.c` migration epic #118.

## What

Promotes four previously-internal helpers to the public API in `dedx.h`, so frontends/bindings (notably the WASM web app) no longer need their own shims:

```c
int   dedx_get_nucleon_number(int ion, int *err);      /* mass number A */
float dedx_get_atom_mass(int ion, int *err);           /* atomic mass, u */
float dedx_get_density(int material, int *err);        /* g/cm³ */
int   dedx_is_gas(int target, int *err);               /* 1 = gas, 0 = condensed/unknown */
```

The implementations already existed inside libdedx (`dedx_internal_get_nucleon`/`_atom_mass` in `dedx_periodic_table.c`, `dedx_internal_read_density`/`_target_is_gas` in `dedx_data_access.c`) — they just lacked a public header entry.

## Why

`dedx_web/wasm/dedx_extra.c` re-exports exactly these four functions because they had no public declaration. This is the smallest, lowest-risk slice of the migration plan and lets the web side delete its shims. It also unblocks dedx_web #175 (display selected-material density) and #176 (custom density).

## Notable detail — a latent out-of-bounds guard

`dedx_internal_get_nucleon()` / `dedx_internal_get_atom_mass()` only guard the **upper** bound (`id < 113`); for `ion <= 0` they would index `dedx_nucl[id-1]` / `dedx_amu[id-1]` at a negative offset. The new public element accessors add the missing lower-bound check and return `-1` with `DEDX_ERR_NOT_AN_ELEMENT` for out-of-range elements. `dedx_get_density` propagates `DEDX_ERR_TARGET_NOT_FOUND` for unknown materials; `dedx_is_gas` normalises the internal `size_t` to `0/1` and reports unknown targets as non-gas (documented).

This partially addresses the "bounds-check name/lookup accessors" item in the health-review epic #108.

## Tests & docs

- **`tests/test_accessors.c`** (new, auto-registered by the `test_*.c` glob): valid values (H/He/C nucleon numbers and masses, water/air density, liquid-vs-gas), out-of-range guards (`0`, negative, `113`, `200`), and the unknown-material error path. Verified against the real embedded data: Carbon A=12 / 12.0107 u, water 1.0 g/cm³ (non-gas), air 1.205e-3 g/cm³ (gas).
- Short usage demo added to `examples/dedx_list.c`.

## Verification

- `ctest`: **28/28 pass** (27 existing + the new test).
- `clang-format --Werror`: clean on all changed files.
- `clang-tidy` (the CI config, `WarningsAsErrors: '*'`): no findings in the added code.

## Open question for maintainers

Final **function names** — I followed the names proposed in #119 and the `dedx_get_*` convention. Happy to rename (e.g. `dedx_get_ion_nucleon_number` to match the web shim, or drop `get_` for the predicate) if you prefer.

---
_Authored via Claude Code as Phase A of the dedx_extra.c → libdedx migration._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdTFfBgkL344BjVrxARiNc)_