### PR TITLE
ci: exclude test sources from coverage and document ignore rationale

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,17 +1,45 @@
+# Codecov configuration for libdedx.
+#
+# Codecov does not instrument or run anything itself. The CMake `coverage`
+# preset compiles the project with --coverage, `ctest` runs the suite, and the
+# resulting gcov/lcov report is uploaded. Codecov then drops everything matched
+# by `ignore:` below and reports the rest as two numbers:
+#   * project — coverage of the whole tracked codebase
+#   * patch   — coverage of just the lines changed in a pull request
+#
+# The intent is to measure how well the tests exercise the shipped *library*
+# (src/, include/) — not the harness, examples, or build plumbing.
+
 coverage:
   status:
     patch:
       default:
-        target: 70%
+        target: 70% # new/changed library lines should be well covered
         threshold: 2%
     project:
       default:
         target: 70%
-        threshold: 1%
+        threshold: 1% # tolerate small dips so unrelated refactors don't fail CI
+
+# Paths excluded from coverage. Coverage should reflect library code only.
 ignore:
+  # Build / CI / packaging config — not compiled C source, nothing to cover.
   - ".github/**"
   - "cmake/**"
   - "**/CMakeLists.txt"
-  - "tests/install_smoke_test.cmake"
-  - "tests/install_consumer_cmake/**"
+
+  # Test harness (subsumes the previously-listed tests/install_* helpers).
+  # Measuring coverage *of the tests themselves* is circular and misleading:
+  # assertion helpers and their "test failed" branches are dead code on a green
+  # run, so counting them only depresses the number without telling us anything
+  # about the library. Best practice is to gate on library coverage and keep
+  # the test sources out of the metric.
+  #
+  # For genuinely unreachable *library* lines (defensive error paths, OOM
+  # guards), mark them in-source with /* LCOV_EXCL_LINE */ or
+  # LCOV_EXCL_START / LCOV_EXCL_STOP — as already done in src/ — rather than
+  # excluding whole files.
+  - "tests/**"
+
+  # Example programs — illustrative usage, not part of the library under test.
   - "examples/**"


### PR DESCRIPTION
## What

Adds `tests/**` to the Codecov `ignore:` list (consolidating the two previously-listed `tests/install_*` entries) and documents *why* each path group is excluded, directly in `.codecov.yml`.

## Why

Codecov doesn't instrument anything itself — the `coverage` CMake preset compiles everything with `--coverage`, `ctest` runs, and the gcov/lcov report is uploaded. Because the test `.c` files are compiled with the same flags and `tests/**` was **not** ignored, coverage was being measured **on the test harness itself**.

That's circular and misleading: assertion helpers and their "test failed" branches are dead code on a green run, so they only depress the patch/project percentages without saying anything about how well `src/` and `include/` are covered. (This is exactly what produced the spurious "missing lines" on the accessor PR #124 — every uncovered line was in the test file's failure paths, not the library.)

Best practice is to gate coverage on **library code only**. This change makes the metric reflect that.

## Notes
- For genuinely unreachable *library* lines (defensive error paths, OOM guards), the repo already uses in-source `/* LCOV_EXCL_LINE */` and `LCOV_EXCL_START/STOP` (e.g. `src/dedx_periodic_table.c`, `src/dedx_mstar.c`, `src/dedx_validate.c`). The added comment points contributors there rather than excluding whole files.
- `examples/**` was already ignored; `tests/**` now matches that same "not the library under test" rationale.
- Config-only change; YAML validated. No source touched.

This is the policy change discussed on #124, split out so it can be reviewed on its own merits.

---
_Authored via Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdTFfBgkL344BjVrxARiNc)_